### PR TITLE
add .bashrc to system subfolder

### DIFF
--- a/system/.bashrc
+++ b/system/.bashrc
@@ -1,0 +1,5 @@
+# .bashrc
+# interactive bash configuration
+
+# If not running interactively, don't do anything
+[[ "$-" != *i* ]] && return


### PR DESCRIPTION
As per title.  .bashrc has no contents behind checking for interactive shell.
