### PR TITLE
add .nanorc to nano subfolder

### DIFF
--- a/nano/.nanorc
+++ b/nano/.nanorc
@@ -1,0 +1,5 @@
+# .nanorc
+# initialization file for GNU nano
+
+set softwrap
+


### PR DESCRIPTION
As per title. .nanorc has no contents beyond setting softwrap.
